### PR TITLE
Append v4 to asset suffix

### DIFF
--- a/local-cli/bundle/assetPathUtils.js
+++ b/local-cli/bundle/assetPathUtils.js
@@ -10,12 +10,12 @@
 
 function getAndroidAssetSuffix(scale) {
   switch (scale) {
-    case 0.75: return 'ldpi';
-    case 1: return 'mdpi';
-    case 1.5: return 'hdpi';
-    case 2: return 'xhdpi';
-    case 3: return 'xxhdpi';
-    case 4: return 'xxxhdpi';
+    case 0.75: return 'ldpi-v4';
+    case 1: return 'mdpi-v4';
+    case 1.5: return 'hdpi-v4';
+    case 2: return 'xhdpi-v4';
+    case 3: return 'xxhdpi-v4';
+    case 4: return 'xxxhdpi-v4';
   }
 }
 


### PR DESCRIPTION
Fix for duplicate image error when trying to assembleRelease the sample app. Got fix from this thread. https://github.com/facebook/react-native/issues/5787